### PR TITLE
fix word over ui

### DIFF
--- a/src/main/java/dtu/dk/View/MainFX.java
+++ b/src/main/java/dtu/dk/View/MainFX.java
@@ -350,7 +350,7 @@ public class MainFX extends Application implements GUIInterface {
 
             wordPane.getChildren().add(wordBox);
             int wordLength = word.getText().length();
-            int x = (int) (Math.random() * (wordPane.getWidth() - wordLength*10));
+            int x = (int) (Math.random() * (wordPane.getWidth() - wordLength * 12));
             x = Math.max(0,x);
             wordBox.setLayoutX(x);
             TranslateTransition transition = new TranslateTransition();

--- a/src/main/java/dtu/dk/View/MainFX.java
+++ b/src/main/java/dtu/dk/View/MainFX.java
@@ -349,7 +349,9 @@ public class MainFX extends Application implements GUIInterface {
             }
 
             wordPane.getChildren().add(wordBox);
-            int x = (int) (Math.random() * (wordPane.getWidth() - wordBox.getWidth()));
+            int wordLength = word.getText().length();
+            int x = (int) (Math.random() * (wordPane.getWidth() - wordLength*10));
+            x = Math.max(0,x);
             wordBox.setLayoutX(x);
             TranslateTransition transition = new TranslateTransition();
             transition.setDuration(Duration.seconds(word.getFallDuration()));


### PR DESCRIPTION
fixed so words dosnt get over ui.

Earlier we used the method getLength() on the words to determine if went over the ui. That didn't work.

So now we get the amount of chars and a magic variable to ensure they dont go over ui